### PR TITLE
Speedup HPS by 5x from Lorentz vector additions

### DIFF
--- a/src/hpsStrip.py
+++ b/src/hpsStrip.py
@@ -1,14 +1,19 @@
 import math
 import vector
+import numpy as np
 
 m_pi0 = 0.135
 
 
 class Strip:
     def __init__(self, cands=[], barcode=-1):
-        sum_p4 = vector.obj(px=0.0, py=0.0, pz=0.0, E=0.0)
-        for cand in cands:
-            sum_p4 = sum_p4 + cand.p4
+        cands_p4 = [c.p4 for c in cands]
+        cands_p4 = np.array([[v.px, v.py, v.pz, v.E] for v in cands_p4])
+        if len(cands_p4) == 0:
+            sum_p4 = vector.obj(px=0, py=0, pz=0, E=0)
+        else:
+            sum_p4 = np.sum(cands_p4, axis=0)
+            sum_p4 = vector.obj(px=sum_p4[0], py=sum_p4[1], pz=sum_p4[2], E=sum_p4[3])
         strip_px = sum_p4.px
         strip_py = sum_p4.py
         strip_pz = sum_p4.pz

--- a/src/hpsTau.py
+++ b/src/hpsTau.py
@@ -1,13 +1,17 @@
 import vector
+import numpy as np
 
 
 class Tau:
     def __init__(self, chargedCands=[], strips=[], barcode=-1):
-        self.p4 = vector.obj(px=0.0, py=0.0, pz=0.0, E=0.0)
-        for chargedCand in chargedCands:
-            self.p4 = self.p4 + chargedCand.p4
-        for strip in strips:
-            self.p4 = self.p4 + strip.p4
+        cands_and_strips = [c.p4 for c in chargedCands] + [s.p4 for s in strips]
+        cands_and_strips = np.array([[v.px, v.py, v.pz, v.E] for v in cands_and_strips])
+        if len(cands_and_strips) == 0:
+            self.p4 = vector.obj(px=0, py=0, pz=0, E=0)
+        else:
+            sum_p4 = np.sum(cands_and_strips, axis=0)
+            self.p4 = vector.obj(px=sum_p4[0], py=sum_p4[1], pz=sum_p4[2], E=sum_p4[3])
+
         self.updatePtEtaPhiMass()
         self.q = 0.0
         for chargedCand in chargedCands:

--- a/src/hpsTauBuilder.py
+++ b/src/hpsTauBuilder.py
@@ -15,13 +15,12 @@ from hpsTau import Tau
 
 
 def data_to_p4s(data):
-    retVal = list(vector.awk(ak.zip({"px": data.x, "py": data.y, "pz": data.z, "mass": data.tau})))
+    retVal = vector.awk(ak.zip({"px": data.x, "py": data.y, "pz": data.z, "mass": data.tau}))
     return retVal
 
 
 def data_to_p4s_x2(data):
     retVal = data_to_p4s(data)
-    retVal = [list(p4s) for p4s in retVal]
     return retVal
 
 
@@ -83,7 +82,6 @@ class HPSTauBuilder(BasicTauBuilder):
         event_cand_charge = data["event_reco_cand_charge"]
 
         jets = buildJets(jet_p4s, jet_cand_p4s, jet_cand_pdg, jet_cand_charge)
-
         taus = []
         for idxJet, jet in enumerate(jets):
             if self.verbosity >= 2:


### PR DESCRIPTION
I did some profiling with [line_profiler](https://github.com/pyutils/line_profiler) and noticed that most of the time is spent in adding up Lorentz vectors.
As far as I can tell, the changes in this PR give exactly the same result, but it's now much faster.

Old:
```
done, saving to  hps/hps/reco_p8_ee_ZH_Htautau_ecm380_905.parquet

real	5m11.483s
user	5m9.821s
sys	0m2.868s
```

New:
```	
done, saving to  hps/hps/reco_p8_ee_ZH_Htautau_ecm380_905.parquet

real	0m53.442s
user	0m51.628s
sys	0m2.978s
```

Tested that the results are the same on one file:
```python3
import awkward as ak

d0 = ak.from_parquet("old.parquet")
d1 = ak.from_parquet("new.parquet")

print(d0["tauClassifier"] - d1["tauClassifier"])
print(d0["tau_decaymode"] - d1["tau_decaymode"])
```

cc @veelken 