### PR TITLE
Fix simple DNN training

### DIFF
--- a/config/endtoend_simple.yaml
+++ b/config/endtoend_simple.yaml
@@ -1,7 +1,7 @@
 train_files: config/datasets/train.yaml
 validation_files: config/datasets/validation.yaml
-epochs: 200
-batch_size: 512
-lr: 0.00001
+epochs: 1000
+batch_size: 4096
+lr: 0.0001
 defaults:
   - tau_builder

--- a/src/endtoend_simple.py
+++ b/src/endtoend_simple.py
@@ -6,8 +6,12 @@ import numpy as np
 import yaml
 import torch
 import torch_geometric
-import torch.nn as nn
+from torch import Tensor, nn
+from torch.nn import functional as F
 import sys
+import tqdm
+import sklearn
+import sklearn.metrics
 from torch_geometric.loader import DataLoader
 from torch_geometric.data.batch import Batch
 from taujetdataset import TauJetDataset
@@ -17,27 +21,37 @@ from basicTauBuilder import BasicTauBuilder
 
 from torch.utils.tensorboard import SummaryWriter
 
+from typing import Optional
+from FocalLoss import FocalLoss
 
 # feedforward network that transformes input_dim->output_dim
 def ffn(input_dim, output_dim, width, act, dropout):
     return nn.Sequential(
-        torch.nn.LayerNorm(input_dim),
         nn.Linear(input_dim, width),
+        torch.nn.LayerNorm(width),
         act(),
         nn.Dropout(dropout),
-        torch.nn.LayerNorm(width),
+
         nn.Linear(width, width),
+        torch.nn.LayerNorm(width),
         act(),
         nn.Dropout(dropout),
-        torch.nn.LayerNorm(width),
+
         nn.Linear(width, width),
+        torch.nn.LayerNorm(width),
         act(),
         nn.Dropout(dropout),
-        torch.nn.LayerNorm(width),
+
         nn.Linear(width, width),
+        torch.nn.LayerNorm(width),
         act(),
         nn.Dropout(dropout),
+
+        nn.Linear(width, width),
         torch.nn.LayerNorm(width),
+        act(),
+        nn.Dropout(dropout),
+
         nn.Linear(width, output_dim),
     )
 
@@ -55,7 +69,7 @@ class EarlyStopper:
             self.counter = 0
         elif validation_loss > (self.min_validation_loss + self.min_delta):
             self.counter += 1
-            if self.counter >= self.patience:
+            if self.patience >=0 and self.counter >= self.patience:
                 print(f"val_los has not decreased in {self.patience} epochs, stopping")
                 return True
         return False
@@ -64,10 +78,11 @@ class EarlyStopper:
 # self-attention layer that transformes [B, N, x] -> [B, N, embedding_dim]
 # by attending the N elements in each batch B
 class SelfAttentionLayer(nn.Module):
-    def __init__(self, embedding_dim=32, num_heads=8, width=128, dropout=0.3):
+    def __init__(self, embedding_dim=32, num_heads=32, width=128, dropout=0.3):
         super(SelfAttentionLayer, self).__init__()
         self.act = nn.ELU
-        self.mha = torch.nn.MultiheadAttention(embedding_dim, num_heads, batch_first=True)
+        self.act_obj = self.act()
+        self.mha = torch.nn.MultiheadAttention(embed_dim=embedding_dim, num_heads=num_heads, batch_first=True, dropout=dropout)
         self.norm0 = torch.nn.LayerNorm(embedding_dim)
         self.norm1 = torch.nn.LayerNorm(embedding_dim)
         self.dropout = torch.nn.Dropout(dropout)
@@ -75,11 +90,13 @@ class SelfAttentionLayer(nn.Module):
 
     def forward(self, x, mask):
         xa = self.mha(x, x, x, key_padding_mask=mask)[0]
-        xa = self.dropout(xa)
         x = self.norm0(x + xa)
+        x = self.act_obj(x)
 
         xa = self.seq(x)
         x = self.norm1(x + xa)
+        x = self.act_obj(x)
+        x = self.dropout(x)
 
         # make sure masked elements are 0
         x = x * (~mask.unsqueeze(-1))
@@ -93,54 +110,56 @@ class TauEndToEndSimple(nn.Module):
         super(TauEndToEndSimple, self).__init__()
 
         self.act = nn.ELU
-        self.dropout = 0.2
-        self.width = 128
-        self.embedding_dim = 128
+        self.act_obj = self.act()
+        self.dropout = 0.1
+        self.width = 512
+        self.embedding_dim = 512
 
-        self.nn_pf_initialembedding = ffn(28, self.embedding_dim, self.width, self.act, self.dropout)
+        self.nn_pf_initialembedding = ffn(14, self.embedding_dim, self.width, self.act, self.dropout)
 
-        self.nn_pf_mha = nn.ModuleList()
-        for i in range(4):
-            self.nn_pf_mha.append(
-                SelfAttentionLayer(embedding_dim=self.embedding_dim, width=self.width, dropout=self.dropout)
-            )
+        # self.nn_pf_mha = nn.ModuleList()
+        # for i in range(1):
+        #     self.nn_pf_mha.append(
+        #         SelfAttentionLayer(embedding_dim=self.embedding_dim, width=self.width, dropout=self.dropout)
+        #     )
 
-        self.nn_pf_ga = AttentionalAggregation(ffn(self.embedding_dim, 1, self.width, self.act, self.dropout))
-        self.agg = torch_geometric.nn.MeanAggregation()
+        self.agg1 = torch_geometric.nn.MeanAggregation()
+        self.agg2 = torch_geometric.nn.MaxAggregation()
+        self.agg3 = torch_geometric.nn.StdAggregation()
 
-        self.nn_pred_istau = ffn(4 + 2 * self.embedding_dim, 1, self.width, self.act, self.dropout)
-        self.nn_pred_p4 = ffn(4 + 2 * self.embedding_dim, 4, self.width, self.act, self.dropout)
+        self.nn_pred_istau = ffn(8 + 3*self.embedding_dim, 2, self.width, self.act, self.dropout)
+        #self.nn_pred_p4 = ffn(8 + 1*self.embedding_dim, 4, self.width, self.act, self.dropout)
 
     def forward(self, batch):
-        pf_encoded = self.nn_pf_initialembedding(batch.jet_pf_features)
+        pf_encoded = self.act_obj(self.nn_pf_initialembedding(batch.jet_pf_features))
 
-        # pad the PF tensors across jets
-        pfs_padded, mask = torch_geometric.utils.to_dense_batch(pf_encoded, batch.jet_pf_features_batch, 0.0)
+        # # pad the PF tensors across jets
+        # pfs_padded, mask = torch_geometric.utils.to_dense_batch(pf_encoded, batch.jet_pf_features_batch, 0.0)
 
-        # run a simple self-attention over the PF candidates in each jet
-        for mha_layer in self.nn_pf_mha:
-            pfs_padded = mha_layer(pfs_padded, ~mask)
+        # # run a simple self-attention over the PF candidates in each jet
+        # for mha_layer in self.nn_pf_mha:
+        #     pfs_padded += self.act_obj(mha_layer(pfs_padded, ~mask))
 
-        # get the encoded PF candidates after attention, undo the padding
-        pf_encoded = torch.cat([pfs_padded[i][mask[i]] for i in range(pfs_padded.shape[0])])
-        assert pf_encoded.shape[0] == batch.jet_pf_features.shape[0]
+        # # get the encoded PF candidates after attention, undo the padding
+        # pf_encoded = torch.cat([pfs_padded[i][mask[i]] for i in range(pfs_padded.shape[0])])
 
-        # now collapse the PF information in each jet with a global attention layer
-        jet_encoded1 = self.nn_pf_ga(pf_encoded, batch.jet_pf_features_batch)
+        # assert pf_encoded.shape[0] == batch.jet_pf_features.shape[0]
 
-        # also compute a simple mean aggregation
-        jet_encoded2 = self.agg(pf_encoded, batch.jet_pf_features_batch)
+        # # now collapse the PF information in each jet with a global attention layer
+        jet_encoded1 = self.act_obj(self.agg1(pf_encoded, batch.jet_pf_features_batch))
+        jet_encoded2 = self.act_obj(self.agg2(pf_encoded, batch.jet_pf_features_batch))
+        jet_encoded3 = self.act_obj(self.agg2(pf_encoded, batch.jet_pf_features_batch))
 
         # get the list of per-jet features as a concat of
-        # (original_features, multi-head attention features)
-        jet_feats = torch.cat([batch.jet_features, jet_encoded1, jet_encoded2], axis=-1)
+        jet_feats = torch.cat([batch.jet_features, jet_encoded1, jet_encoded2, jet_encoded3], axis=-1)
 
         # run a binary classification whether or not this jet is from a tau
-        pred_istau = self.nn_pred_istau(jet_feats).squeeze(-1)
+        pred_istau = self.nn_pred_istau(jet_feats)
 
         # run a per-jet NN for visible energy prediction
         jet_p4 = batch.jet_features[:, :4]
-        pred_p4 = jet_p4 * self.nn_pred_p4(jet_feats)
+        #pred_p4 = jet_p4 * self.nn_pred_p4(jet_feats)
+        pred_p4 = jet_p4
 
         return pred_istau, pred_p4
 
@@ -151,13 +170,17 @@ def weighted_huber_loss(pred_tau_p4, true_tau_p4, weights):
     return weighted_losses.mean()
 
 
+#focal_loss = FocalLoss(gamma=2.0)
+focal_loss = torch.nn.CrossEntropyLoss(reduction="none")
 def weighted_bce_with_logits(pred_istau, true_istau, weights):
-    loss_cls = 10000.0 * torch.nn.functional.binary_cross_entropy_with_logits(pred_istau, true_istau, reduction="none")
+    loss_cls = 10000.0 * focal_loss(pred_istau, true_istau.long())
     weighted_loss_cls = loss_cls * weights
     return weighted_loss_cls.mean()
 
 
-def model_loop(model, ds_loader, optimizer, scheduler, is_train, dev):
+ISTEP_GLOBAL = 0
+def model_loop(model, ds_loader, optimizer, scheduler, is_train, dev, tensorboard_writer):
+    global ISTEP_GLOBAL
     loss_cls_tot = 0.0
     loss_p4_tot = 0.0
 
@@ -171,7 +194,8 @@ def model_loop(model, ds_loader, optimizer, scheduler, is_train, dev):
 
     class_true = []
     class_pred = []
-    for batch in ds_loader:
+    for ibatch, batch in enumerate(tqdm.tqdm(ds_loader, total=len(ds_loader))):
+        optimizer.zero_grad()
         batch = batch.to(device=dev)
         pred_istau, pred_p4 = model(batch)
         true_p4 = batch.gen_tau_p4
@@ -179,7 +203,7 @@ def model_loop(model, ds_loader, optimizer, scheduler, is_train, dev):
         pred_p4 = pred_p4 * true_istau.unsqueeze(-1)
         weights = batch.weight
 
-        loss_p4 = weighted_huber_loss(pred_p4[true_istau == 1], true_p4[true_istau == 1], weights[true_istau == 1])
+        loss_p4 = 0.0*weighted_huber_loss(pred_p4, true_p4, weights)
         loss_cls = weighted_bce_with_logits(pred_istau, true_istau, weights)
 
         loss = loss_cls + loss_p4
@@ -187,23 +211,26 @@ def model_loop(model, ds_loader, optimizer, scheduler, is_train, dev):
             loss.backward()
             optimizer.step()
             scheduler.step()
+            ISTEP_GLOBAL += 1
+            tensorboard_writer.add_scalar("step/train_loss", loss.detach().cpu().item(), ISTEP_GLOBAL)
+            tensorboard_writer.add_scalar("step/num_signal", torch.sum(true_istau).cpu().item(), ISTEP_GLOBAL)
         else:
             class_true.append(true_istau.cpu().numpy())
-            class_pred.append(torch.sigmoid(pred_istau).detach().cpu().numpy())
+            class_pred.append(torch.softmax(pred_istau, axis=-1)[:, 1].detach().cpu().numpy())
         loss_cls_tot += loss_cls.detach().cpu().item()
         loss_p4_tot += loss_p4.detach().cpu().item()
         nsteps += 1
         njets += batch.jet_features.shape[0]
-        print(
-            "jets={jets} pfs={pfs} max_pfs={max_pfs} ntau={ntau} loss={loss:.2f} lr={lr:.2E}".format(
-                jets=batch.jet_features.shape[0],
-                pfs=batch.jet_pf_features.shape[0],
-                max_pfs=np.max(np.unique(batch.jet_pf_features_batch.cpu().numpy(), return_counts=True)[1]),
-                ntau=true_istau.sum().cpu().item(),
-                loss=loss.detach().cpu().item(),
-                lr=scheduler.get_last_lr()[0],
-            )
-        )
+        #print(
+        #    "jets={jets} pfs={pfs} max_pfs={max_pfs} ntau={ntau} loss={loss:.2f} lr={lr:.2E}".format(
+        #        jets=batch.jet_features.shape[0],
+        #        pfs=batch.jet_pf_features.shape[0],
+        #        max_pfs=np.max(np.unique(batch.jet_pf_features_batch.cpu().numpy(), return_counts=True)[1]),
+        #        ntau=true_istau.sum().cpu().item(),
+        #        loss=loss.detach().cpu().item(),
+        #        lr=scheduler.get_last_lr()[0],
+        #    )
+        #)
         sys.stdout.flush()
     if not is_train:
         class_true = np.concatenate(class_true)
@@ -232,7 +259,7 @@ class SimpleDNNTauBuilder(BasicTauBuilder):
         data_obj = Batch.from_data_list(ds.process_file_data(jets), follow_batch=["jet_pf_features"])
         pred_istau, pred_p4 = self.model(data_obj)
 
-        pred_istau = torch.sigmoid(pred_istau)
+        pred_istau = torch.softmax(pred_istau, axis=-1)[:, 1]
         pred_istau = pred_istau.contiguous().detach().numpy()
         # to solve "ValueError: ndarray is not contiguous"
         pred_p4 = np.asfortranarray(pred_p4.detach().contiguous().numpy())
@@ -282,6 +309,9 @@ def main(cfg):
     files_train = get_split_files(cfg.train_files, "train")
     files_val = get_split_files(cfg.validation_files, "validation")
 
+    files_train = [f.replace("/scratch-persistent/laurits", "data") for f in files_train]
+    files_val = [f.replace("/scratch-persistent/laurits", "data") for f in files_val]
+
     if cfg.n_files == -1:
         n_files = None
     else:
@@ -309,20 +339,21 @@ def main(cfg):
     print("params={}".format(count_parameters(model)))
 
     optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
-    scheduler = torch.optim.lr_scheduler.OneCycleLR(
-        optimizer, max_lr=cfg.lr, steps_per_epoch=len(ds_train_loader), epochs=cfg.epochs
-    )
+    # scheduler = torch.optim.lr_scheduler.OneCycleLR(
+    #     optimizer, max_lr=cfg.lr, steps_per_epoch=len(ds_train_loader), epochs=cfg.epochs
+    # )
+    scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda epoch: 1.0)
 
     tensorboard_writer = SummaryWriter(outpath + "/tensorboard")
-    early_stopper = EarlyStopper(patience=15, min_delta=10)
+    early_stopper = EarlyStopper(patience=-1, min_delta=10)
 
     for iepoch in range(cfg.epochs):
-        loss_cls_train, loss_p4_train, _ = model_loop(model, ds_train_loader, optimizer, scheduler, True, dev)
+        loss_cls_train, loss_p4_train, _ = model_loop(model, ds_train_loader, optimizer, scheduler, True, dev, tensorboard_writer)
         tensorboard_writer.add_scalar("epoch/train_cls_loss", loss_cls_train, iepoch)
         tensorboard_writer.add_scalar("epoch/train_p4_loss", loss_p4_train, iepoch)
         tensorboard_writer.add_scalar("epoch/train_loss", loss_cls_train + loss_p4_train, iepoch)
 
-        loss_cls_val, loss_p4_val, retvals = model_loop(model, ds_val_loader, optimizer, scheduler, False, dev)
+        loss_cls_val, loss_p4_val, retvals = model_loop(model, ds_val_loader, optimizer, scheduler, False, dev, tensorboard_writer)
 
         tensorboard_writer.add_scalar("epoch/val_cls_loss", loss_cls_val, iepoch)
         tensorboard_writer.add_scalar("epoch/val_p4_loss", loss_p4_val, iepoch)
@@ -331,12 +362,15 @@ def main(cfg):
         tensorboard_writer.add_scalar("epoch/lr", scheduler.get_last_lr()[0], iepoch)
         tensorboard_writer.add_pr_curve("epoch/roc_curve", retvals[0], retvals[1], iepoch)
 
+        fpr, tpr, thresh = sklearn.metrics.roc_curve(retvals[0], retvals[1])
+        tensorboard_writer.add_scalar("epoch/fpr_at_tpr0p6", fpr[np.searchsorted(tpr, 0.6)], iepoch)
+
         print(
             "epoch={} cls={:.4f}/{:.4f} p4={:.4f}/{:.4f}".format(
                 iepoch, loss_cls_train, loss_cls_val, loss_p4_train, loss_p4_val
             )
         )
-        torch.save(model, "{}/model_{}.pt".format(outpath, iepoch))
+        #torch.save(model, "{}/model_{}.pt".format(outpath, iepoch))
         if early_stopper.early_stop(loss_cls_val):
             break
 

--- a/src/runBuilder.py
+++ b/src/runBuilder.py
@@ -12,7 +12,7 @@ from oracleTauBuilder import OracleTauBuilder
 from hpsTauBuilder import HPSTauBuilder
 from build_grid import GridBuilder
 from endtoend_simple import SimpleDNNTauBuilder
-from endtoend_simple import TauEndToEndSimple, SelfAttentionLayer
+from endtoend_simple import TauEndToEndSimple
 from fastCMSTauBuilder import FastCMSTauBuilder
 from LorentzNetTauBuilder import LorentzNetTauBuilder
 from ParticleTransformerTauBuilder import ParticleTransformerTauBuilder
@@ -47,7 +47,6 @@ def build_taus(cfg: DictConfig) -> None:
     elif cfg.builder == "SimpleDNN":
         pytorch_model = torch.load("data/model.pt", map_location=torch.device("cpu"))
         assert pytorch_model.__class__ == TauEndToEndSimple
-        assert pytorch_model.nn_pf_mha[0].__class__ == SelfAttentionLayer
         builder = SimpleDNNTauBuilder(pytorch_model)
     elif cfg.builder == "LorentzNet":
         builder = LorentzNetTauBuilder(verbosity=cfg.verbosity)

--- a/src/taujetdataset.py
+++ b/src/taujetdataset.py
@@ -6,7 +6,7 @@ from torch_geometric.data import Data, Dataset
 import os.path as osp
 from glob import glob
 import vector
-import random
+
 
 def chunks(lst, n):
     """Yield successive n-sized chunks from lst."""
@@ -26,28 +26,28 @@ class TauJetDataset(Dataset):
         self.pf_features = ["x", "y", "z", "tau", "pt", "eta", "phi", "e", "charge", "is_ch_had", "is_n_had", "is_gamma", "is_ele", "is_mu"]
 
         self.pf_extras = [
-            # "reco_cand_dxy",
-            # "reco_cand_dz",
-            # "reco_cand_signed_dxy",
-            # "reco_cand_signed_dz",
-            # "reco_cand_signed_d3",
-            # "reco_cand_d3",
-            # "reco_cand_d0",
-            # "reco_cand_z0",
-            # "reco_cand_PCA_x",
-            # "reco_cand_PCA_y",
-            # "reco_cand_PCA_z",
-            # "reco_cand_PV_x",
-            # "reco_cand_PV_y",
-            # "reco_cand_PV_z",
-            # "reco_cand_dxy_err",
-            # "reco_cand_dz_err",
-            # "reco_cand_d3_err",
-            # "reco_cand_d0_err",
-            # "reco_cand_z0_err",
-            # "reco_cand_PCA_x_err",
-            # "reco_cand_PCA_y_err",
-            # "reco_cand_PCA_z_err",
+            "reco_cand_dxy",
+            "reco_cand_dz",
+            "reco_cand_signed_dxy",
+            "reco_cand_signed_dz",
+            "reco_cand_signed_d3",
+            "reco_cand_d3",
+            "reco_cand_d0",
+            "reco_cand_z0",
+            "reco_cand_PCA_x",
+            "reco_cand_PCA_y",
+            "reco_cand_PCA_z",
+            "reco_cand_PV_x",
+            "reco_cand_PV_y",
+            "reco_cand_PV_z",
+            "reco_cand_dxy_err",
+            "reco_cand_dz_err",
+            "reco_cand_d3_err",
+            "reco_cand_d0_err",
+            "reco_cand_z0_err",
+            "reco_cand_PCA_x_err",
+            "reco_cand_PCA_y_err",
+            "reco_cand_PCA_z_err",
         ]
         # just load all data to memory
         self.all_data = []
@@ -55,8 +55,6 @@ class TauJetDataset(Dataset):
             print(fn)
             data = ak.from_parquet(fn)
             self.all_data += self.process_file_data(data)
-
-        random.shuffle(self.all_data)
 
     @property
     def processed_file_names(self):

--- a/src/taujetdataset.py
+++ b/src/taujetdataset.py
@@ -23,7 +23,22 @@ class TauJetDataset(Dataset):
         self.reco_jet_features = ["x", "y", "z", "tau", "pt", "eta", "phi", "e"]
 
         # The order of features in the PF feature tensor
-        self.pf_features = ["x", "y", "z", "tau", "pt", "eta", "phi", "e", "charge", "is_ch_had", "is_n_had", "is_gamma", "is_ele", "is_mu"]
+        self.pf_features = [
+            "x",
+            "y",
+            "z",
+            "tau",
+            "pt",
+            "eta",
+            "phi",
+            "e",
+            "charge",
+            "is_ch_had",
+            "is_n_had",
+            "is_gamma",
+            "is_ele",
+            "is_mu",
+        ]
 
         self.pf_extras = [
             "reco_cand_dxy",
@@ -112,11 +127,11 @@ class TauJetDataset(Dataset):
         pfs["phi"] = pfP4.phi
         pfs["e"] = pfP4.energy
 
-        pfs["is_ch_had"] = (pfs["pdg"] == 211)
-        pfs["is_n_had"] = (pfs["pdg"] == 130)
-        pfs["is_gamma"] = (pfs["pdg"] == 22)
-        pfs["is_ele"] = (pfs["pdg"] == 11)
-        pfs["is_mu"] = (pfs["pdg"] == 13)
+        pfs["is_ch_had"] = pfs["pdg"] == 211
+        pfs["is_n_had"] = pfs["pdg"] == 130
+        pfs["is_gamma"] = pfs["pdg"] == 22
+        pfs["is_ele"] = pfs["pdg"] == 11
+        pfs["is_mu"] = pfs["pdg"] == 13
 
         # collect PF features in a specific order to an (Ncand x Nfeatcand) torch tensor
         pf_feature_tensors = []


### PR DESCRIPTION
Training was missing optimizer.zero_grad...

The purpose of the simple DNN is to have a network that does no candidate-to-candidate communication, but rather just computes output as follows:

```
jet_prediction = net2(jet_features, agg(net1(jet_pf_features))

net1: simple FFN applied on each PF candidate in the jet
agg: compute a mean, max, stddev across all PFCandidates for each jet
net1: simple FFN applied on each jet, taking the jet properties and the aggregated PFCandidate properties
```

It's fast to train and serves as the baseline against which to compare more complex HEP-specific architectures.
 
<img width="1143" alt="Screenshot 2023-03-15 at 20 21 09" src="https://user-images.githubusercontent.com/69717/225406074-b4a2f809-a339-4622-a68a-df2b417ed53e.png">
<img width="528" alt="Screenshot 2023-03-15 at 20 21 41" src="https://user-images.githubusercontent.com/69717/225406127-9d3ffb90-312b-45be-bad3-9b22005a4c93.png">
